### PR TITLE
Temporary fix scipy complain about imresize

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ This project was implemented using [TensorFlow](https://www.tensorflow.org/) and
  - [Python 3 (3.6)](https://www.python.org/)
  - [TensorFlow (1.12)](https://www.tensorflow.org/)
  - [NumPy](http://www.numpy.org/)
- - [SciPy](https://www.scipy.org/)
+ - [SciPy 1.1.0](https://www.scipy.org/)
+ On pip, use `pip install scipy==1.1.0`
  - [Matplotlib](https://matplotlib.org/)
  - [Imageio](https://imageio.github.io/)
  - [Tqdm](https://pypi.org/project/tqdm/)


### PR DESCRIPTION
Scipy now throws this error
`AttributeError: module 'scipy.misc' has no attribute 'imresize'`
due to the deprecation of imresize in scipy in >1.1.0
Installing scipy version 1.1.0 fixes this problem.

Although a more thorough code inspection might be needed to fix this problem to work with the newest version.